### PR TITLE
Hide private fields in object monitor

### DIFF
--- a/src/lu/fisch/unimozer/Mainform.form
+++ b/src/lu/fisch/unimozer/Mainform.form
@@ -704,6 +704,14 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chkRealtimeActionPerformed"/>
               </Events>
             </MenuItem>
+            <MenuItem class="javax.swing.JCheckBoxMenuItem" name="chkHidePrivateFields">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="Hide private fields in object monitor"/>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chkHidePrivateFieldsActionPerformed"/>
+              </Events>
+            </MenuItem>
           </SubComponents>
         </Menu>
         <Menu class="javax.swing.JMenu" name="mHelp">

--- a/src/lu/fisch/unimozer/Mainform.java
+++ b/src/lu/fisch/unimozer/Mainform.java
@@ -616,6 +616,7 @@ public class Mainform extends JFrame
         shVeryStrong = new javax.swing.JRadioButtonMenuItem();
         shCostum = new javax.swing.JRadioButtonMenuItem();
         chkRealtime = new javax.swing.JCheckBoxMenuItem();
+        chkHidePrivateFields = new javax.swing.JCheckBoxMenuItem();
         mHelp = new javax.swing.JMenu();
         miAbout = new javax.swing.JMenuItem();
         miBootLogReport = new javax.swing.JMenuItem();
@@ -1647,6 +1648,14 @@ public class Mainform extends JFrame
         });
         mOptions.add(chkRealtime);
 
+        chkHidePrivateFields.setText("Hide private fields in object monitor");
+        chkHidePrivateFields.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                chkHidePrivateFieldsActionPerformed(evt);
+            }
+        });
+        mOptions.add(chkHidePrivateFields);
+
         jMenuBar.add(mOptions);
 
         mHelp.setText("Help");
@@ -2356,12 +2365,25 @@ public class Mainform extends JFrame
         dg.setVisible(true);
     }//GEN-LAST:event_miCreateInteractiveActionPerformed
 
+    private void chkHidePrivateFieldsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_chkHidePrivateFieldsActionPerformed
+        if(chkHidePrivateFields.isSelected())
+        {
+            objectizer.setHidePrivateFields(true);
+        }
+        else
+        {
+            objectizer.setHidePrivateFields(false);
+        }
+        objectizer.repaint();
+    }//GEN-LAST:event_chkHidePrivateFieldsActionPerformed
+
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.ButtonGroup actionGroup;
     private javax.swing.JPanel bottomPanel;
     private javax.swing.JSplitPane bottomSplitter;
     private javax.swing.JLabel callingLabel;
+    private javax.swing.JCheckBoxMenuItem chkHidePrivateFields;
     private javax.swing.JCheckBoxMenuItem chkRealtime;
     private lu.fisch.unimozer.CodeEditor codeEditor;
     lu.fisch.unimozer.console.Console console;
@@ -2371,7 +2393,7 @@ public class Mainform extends JFrame
     private javax.swing.JPanel jPanel1;
     private javax.swing.JSeparator jSeparator1;
     private javax.swing.JPopupMenu.Separator jSeparator10;
-    private javax.swing.JSeparator jSeparator11;
+    private javax.swing.JPopupMenu.Separator jSeparator11;
     private javax.swing.JPopupMenu.Separator jSeparator2;
     private javax.swing.JSeparator jSeparator3;
     private javax.swing.JSeparator jSeparator4;

--- a/src/lu/fisch/unimozer/MyObject.java
+++ b/src/lu/fisch/unimozer/MyObject.java
@@ -28,6 +28,7 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Window;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Hashtable;
 import java.util.Vector;
 
@@ -190,7 +191,11 @@ public class MyObject
         }
     }
 
-    public int paint(Graphics2D g, int x, int y, boolean isUML)
+    public int paint(Graphics2D g, int x, int y, boolean isUML) {
+        return paint(g, x, y, isUML, false);
+    }
+    
+    public int paint(Graphics2D g, int x, int y, boolean isUML, boolean hidePrivateFields)
     {
           String className = "<?>";
           if (this.getMyClass()!=null) className=this.getMyClass().getShortName();
@@ -226,6 +231,8 @@ public class MyObject
                     Field field = c.getDeclaredFields()[f];
                     //System.out.println("Found field: "+field.getName());
                     field.setAccessible(true);
+                    if (hidePrivateFields && Modifier.isPrivate(field.getModifiers()))
+                        continue;
                     String display = field.getName() + " = ?";
                     try
                     {
@@ -251,14 +258,11 @@ public class MyObject
                         else
                             display = field.getName() + " = <NULL>";
                     }
-                    catch (IllegalArgumentException ex)
+                    catch (IllegalArgumentException | IllegalAccessException ex)
                     {
                         //ex.printStackTrace();
                     }
-                    catch (IllegalAccessException ex)
-                    {
-                        //ex.printStackTrace();
-                    }
+                      //ex.printStackTrace();
                     g.setFont(new Font(g.getFont().getName(),Font.PLAIN,g.getFont().getSize()));
 
                     if(display.length()>50) display=display.substring(0,47)+"...";
@@ -315,6 +319,8 @@ public class MyObject
               {
                 Field field = c.getDeclaredFields()[f];  
                 field.setAccessible(true);
+                if (hidePrivateFields && Modifier.isPrivate(field.getModifiers()))
+                    continue;
                 String display = field.getName() + " = ?";
                 try
                 {
@@ -341,14 +347,11 @@ public class MyObject
                         display = field.getName() + " = <NULL>";
                     //display = field.getName() + " = " + field.get(getObject()).toString();
                 }
-                catch (IllegalArgumentException ex)
+                catch (IllegalArgumentException | IllegalAccessException ex)
                 {
                     //ex.printStackTrace();
                 }
-                catch (IllegalAccessException ex)
-                {
-                    //ex.printStackTrace();
-                }
+                  //ex.printStackTrace();
 
                 if(display.length()>50) display=display.substring(0,47)+"...";
 
@@ -376,6 +379,8 @@ public class MyObject
                       {
                         Field field = c.getDeclaredFields()[f];  
                         field.setAccessible(true);
+                        if (hidePrivateFields && Modifier.isPrivate(field.getModifiers()))
+                            continue;
                         String display = field.getName() + " = ?";
                         try
                         {
@@ -402,14 +407,11 @@ public class MyObject
                                 display = field.getName() + " = <NULL>";
                             //display = field.getName() + " = " + field.get(getObject()).toString();
                         }
-                        catch (IllegalArgumentException exi)
+                        catch (IllegalArgumentException | IllegalAccessException exi)
                         {
                             //exi.printStackTrace();
                         }
-                        catch (IllegalAccessException exi)
-                        {
-                            //exi.printStackTrace();
-                        }
+                          //exi.printStackTrace();
 
                         if(display.length()>50) display=display.substring(0,47)+"...";
 

--- a/src/lu/fisch/unimozer/Objectizer.java
+++ b/src/lu/fisch/unimozer/Objectizer.java
@@ -83,6 +83,8 @@ public class Objectizer extends JPanel implements MouseListener, ActionListener,
     private JLabel calling = null;
     /** holds the references to the different thread created */
     private Vector<Thread> threads = new Vector<Thread>();
+    /** whether to hide private fields */
+    private boolean hidePrivateFields = false;
     
     private static Objectizer self = null;
 
@@ -389,7 +391,7 @@ public class Objectizer extends JPanel implements MouseListener, ActionListener,
             {
                 String objectName = (String) objects.keySet().toArray()[o];
                 MyObject myObj = objects.get(objectName);
-                left+=myObj.paint(g, left, 8, diagram.isUML())+8;
+                left+=myObj.paint(g, left, 8, diagram.isUML(), hidePrivateFields)+8;
             }
         }
         catch (Error e)
@@ -2006,6 +2008,10 @@ public class Objectizer extends JPanel implements MouseListener, ActionListener,
     @Override
     public void windowDeactivated(WindowEvent e)
     {
+    }
+    
+    public void setHidePrivateFields(boolean hidePrivateFields) {
+        this.hidePrivateFields = hidePrivateFields;
     }
 
     /**


### PR DESCRIPTION
Added the possibility to toggle the visibility of private fields in the object monitor through a checkbox in the "Options" menu.

This could be helpful to explain the difference between private and public fields and prevent students from seeing the value of fields without using the corresponding getters.